### PR TITLE
Inhibit iOS 9 action sheet deprecation warning

### DIFF
--- a/NimbusKit-AttributedLabel.podspec
+++ b/NimbusKit-AttributedLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "NimbusKit-AttributedLabel"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1e"
   s.license      =  { :type => 'BSD' }
   s.summary      = "UILabel subsitute with Core Text rendering, link detection, and inline images."
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.social_media_url = "http://twitter.com/featherless"
   s.requires_arc = true
   s.platform = :ios, '6.0'
-  s.source       = { :git => "https://github.com/nimbuskit/attributedlabel.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/nimbuskit/attributedlabel.git", :tag => "1.0.1e" }
   s.source_files  = 'src'
   s.public_header_files = 'src/{NimbusKitAttributedLabel,NIAttributedLabel}.h'
   s.frameworks = 'CoreText', 'CoreGraphics', 'QuartzCore'

--- a/src/NIAttributedLabel.h
+++ b/src/NIAttributedLabel.h
@@ -144,7 +144,7 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
  * @returns YES if @c actionSheet should be displayed. NO if @c actionSheet should not be
  *               displayed.
  */
-- (BOOL)attributedLabel:(NIAttributedLabel *)attributedLabel shouldPresentActionSheet:(UIActionSheet *)actionSheet withTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point;
+- (BOOL)attributedLabel:(NIAttributedLabel *)attributedLabel shouldPresentActionSheet:(id)actionSheet withTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point;
 
 @end
 


### PR DESCRIPTION
This is a workaround until [IOS-10672](https://jiraeyeem.atlassian.net/browse/IOS-10672) is implemented